### PR TITLE
Moving react to v15.5 to remove warning 'Warning: Accessing PropTypes…

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,16 +68,16 @@
     "node-sass": "^3.2.0",
     "npm-run-all": "^1.2.6",
     "postcss-cli": "^1.5.0",
-    "react": "^15.0",
-    "react-addons-test-utils": "^15.0",
-    "react-dom": "^15.0",
+    "react": "^15.5",
+    "react-addons-test-utils": "^15.5",
+    "react-dom": "^15.5",
     "rimraf": "^2.3.4",
     "sinon": "^1.15.4",
     "sinon-chai": "^2.8.0",
     "webpack": "^1.11.0"
   },
   "peerDependencies": {
-    "react": "^0.14 || ^15.0",
-    "react-dom": "^0.14 || ^15.0"
+    "react": "^0.14 || ^15.5",
+    "react-dom": "^0.14 || ^15.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "classnames": "^2.2.0",
     "lodash.isnumber": "^3.0.1",
-    "react-prop-types": "^0.3.0",
+    "prop-types": "^15.5.10",
     "react-pure-render": "^1.0.2"
   },
   "devDependencies": {
@@ -71,6 +71,7 @@
     "react": "^15.5",
     "react-addons-test-utils": "^15.5",
     "react-dom": "^15.5",
+    "react-prop-types": "^0.3.0",
     "rimraf": "^2.3.4",
     "sinon": "^1.15.4",
     "sinon-chai": "^2.8.0",

--- a/src/Col.jsx
+++ b/src/Col.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import PureComponent from 'react-pure-render/component';
 import classNames from 'classnames';
 import { elementType } from 'react-prop-types';
@@ -41,44 +42,44 @@ class Col extends PureComponent {
 }
 
 Col.propTypes = {
-  className: React.PropTypes.string,
-  style: React.PropTypes.object,
-  children: React.PropTypes.node,
+  className: PropTypes.string,
+  style: PropTypes.object,
+  children: PropTypes.node,
   componentClass: elementType,
 
-  xs: React.PropTypes.oneOfType([
-    React.PropTypes.number,
-    React.PropTypes.bool,
+  xs: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.bool,
   ]),
-  sm: React.PropTypes.oneOfType([
-    React.PropTypes.number,
-    React.PropTypes.bool,
+  sm: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.bool,
   ]),
-  md: React.PropTypes.oneOfType([
-    React.PropTypes.number,
-    React.PropTypes.bool,
+  md: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.bool,
   ]),
-  lg: React.PropTypes.oneOfType([
-    React.PropTypes.number,
-    React.PropTypes.bool,
+  lg: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.bool,
   ]),
 
-  xsOffset: React.PropTypes.number,
-  smOffset: React.PropTypes.number,
-  mdOffset: React.PropTypes.number,
-  lgOffset: React.PropTypes.number,
+  xsOffset: PropTypes.number,
+  smOffset: PropTypes.number,
+  mdOffset: PropTypes.number,
+  lgOffset: PropTypes.number,
 
-  reverse: React.PropTypes.bool,
+  reverse: PropTypes.bool,
 
-  xsFirst: React.PropTypes.bool,
-  smFirst: React.PropTypes.bool,
-  mdFirst: React.PropTypes.bool,
-  lgFirst: React.PropTypes.bool,
+  xsFirst: PropTypes.bool,
+  smFirst: PropTypes.bool,
+  mdFirst: PropTypes.bool,
+  lgFirst: PropTypes.bool,
 
-  xsLast: React.PropTypes.bool,
-  smLast: React.PropTypes.bool,
-  mdLast: React.PropTypes.bool,
-  lgLast: React.PropTypes.bool,
+  xsLast: PropTypes.bool,
+  smLast: PropTypes.bool,
+  mdLast: PropTypes.bool,
+  lgLast: PropTypes.bool,
 };
 
 Col.defaultProps = {

--- a/src/Grid.jsx
+++ b/src/Grid.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import PureComponent from 'react-pure-render/component';
 import classNames from 'classnames';
+
 import { elementType } from 'react-prop-types';
 
 class Grid extends PureComponent {
@@ -21,10 +23,10 @@ class Grid extends PureComponent {
 }
 
 Grid.propTypes = {
-  fluid: React.PropTypes.bool,
-  className: React.PropTypes.string,
-  style: React.PropTypes.object,
-  children: React.PropTypes.node,
+  fluid: PropTypes.bool,
+  className: PropTypes.string,
+  style: PropTypes.object,
+  children: PropTypes.node,
   componentClass: elementType,
 };
 

--- a/src/Row.jsx
+++ b/src/Row.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import PureComponent from 'react-pure-render/component';
 import classNames from 'classnames';
 import { elementType } from 'react-prop-types';
@@ -61,51 +62,51 @@ class Row extends PureComponent {
 }
 
 Row.propTypes = {
-  reverse: React.PropTypes.bool,
-  className: React.PropTypes.string,
-  style: React.PropTypes.object,
-  children: React.PropTypes.node,
+  reverse: PropTypes.bool,
+  className: PropTypes.string,
+  style: PropTypes.object,
+  children: PropTypes.node,
   componentClass: elementType,
 
-  xsStart: React.PropTypes.bool,
-  smStart: React.PropTypes.bool,
-  mdStart: React.PropTypes.bool,
-  lgStart: React.PropTypes.bool,
+  xsStart: PropTypes.bool,
+  smStart: PropTypes.bool,
+  mdStart: PropTypes.bool,
+  lgStart: PropTypes.bool,
 
-  xsCenter: React.PropTypes.bool,
-  smCenter: React.PropTypes.bool,
-  mdCenter: React.PropTypes.bool,
-  lgCenter: React.PropTypes.bool,
+  xsCenter: PropTypes.bool,
+  smCenter: PropTypes.bool,
+  mdCenter: PropTypes.bool,
+  lgCenter: PropTypes.bool,
 
-  xsEnd: React.PropTypes.bool,
-  smEnd: React.PropTypes.bool,
-  mdEnd: React.PropTypes.bool,
-  lgEnd: React.PropTypes.bool,
+  xsEnd: PropTypes.bool,
+  smEnd: PropTypes.bool,
+  mdEnd: PropTypes.bool,
+  lgEnd: PropTypes.bool,
 
-  xsTop: React.PropTypes.bool,
-  smTop: React.PropTypes.bool,
-  mdTop: React.PropTypes.bool,
-  lgTop: React.PropTypes.bool,
+  xsTop: PropTypes.bool,
+  smTop: PropTypes.bool,
+  mdTop: PropTypes.bool,
+  lgTop: PropTypes.bool,
 
-  xsMiddle: React.PropTypes.bool,
-  smMiddle: React.PropTypes.bool,
-  mdMiddle: React.PropTypes.bool,
-  lgMiddle: React.PropTypes.bool,
+  xsMiddle: PropTypes.bool,
+  smMiddle: PropTypes.bool,
+  mdMiddle: PropTypes.bool,
+  lgMiddle: PropTypes.bool,
 
-  xsBottom: React.PropTypes.bool,
-  smBottom: React.PropTypes.bool,
-  mdBottom: React.PropTypes.bool,
-  lgBottom: React.PropTypes.bool,
+  xsBottom: PropTypes.bool,
+  smBottom: PropTypes.bool,
+  mdBottom: PropTypes.bool,
+  lgBottom: PropTypes.bool,
 
-  xsAround: React.PropTypes.bool,
-  smAround: React.PropTypes.bool,
-  mdAround: React.PropTypes.bool,
-  lgAround: React.PropTypes.bool,
+  xsAround: PropTypes.bool,
+  smAround: PropTypes.bool,
+  mdAround: PropTypes.bool,
+  lgAround: PropTypes.bool,
 
-  xsBetween: React.PropTypes.bool,
-  smBetween: React.PropTypes.bool,
-  mdBetween: React.PropTypes.bool,
-  lgBetween: React.PropTypes.bool,
+  xsBetween: PropTypes.bool,
+  smBetween: PropTypes.bool,
+  mdBetween: PropTypes.bool,
+  lgBetween: PropTypes.bool,
 };
 
 Row.defaultProps = {


### PR DESCRIPTION
… via the main React package is deprecated. Use the prop-types package from npm instead